### PR TITLE
Add support for different image formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ API keys are sent to the service using the Authorization Bearer scheme.
 
 The root path `/` returns status 200 if online, plus some Gilbert and Sullivan lyrics (you can go there in your browser to see if it's online).
 
-The only other path is `/scrape`, to which you send a JSON formatted POST request and (if all things go well) receive a `multipart/mixed` type response.
+The only other path is `/scrape`, to which you send a JSON formatted POST request and (if all things go well) receive a `multipart/mixed` type response. You could provide the desired output image format as Accept header MIME type. If no Accept header is provided, the screenshots are saved by default in JPEG format. The following values are supported:
+- image/webp
+- image/png
+- image/jpeg
 
 The response will be either:
 
@@ -125,7 +128,7 @@ You can control memory limits and other variables at the top of `scraper/worker.
 ```
 MEM_LIMIT_MB = 4_000  # 4 GB memory threshold for child scraping process
 MAX_SCREENSHOTS = 5
-SCREENSHOT_JPEG_QUALITY = 85
+SCREENSHOT_QUALITY = 85
 BROWSER_HEIGHT = 2000
 BROWSER_WIDTH = 1280
 USER_AGENT = "Mozilla/5.0 (compatible; Abbey/1.0; +https://github.com/US-Artificial-Intelligence/scraper)"


### PR DESCRIPTION
Add support for the following output image formats:
- image/webp
- image/png
- image/jpeg

If no Accept header is provided, the images are saved in JPEG by default.

If an invalid Accept header is provided, throw a HTTP 406 Not Acceptable error with a list of accepted values.

Closes #4.